### PR TITLE
Extend script to support RSA formatted private keys as well.

### DIFF
--- a/opnsense-import-ssl.php
+++ b/opnsense-import-ssl.php
@@ -65,7 +65,7 @@ if (! file_exists($argv[2])) {
 }
 
 $key = trim(file_get_contents($argv[2]));
-if (! preg_match('/^-----BEGIN PRIVATE KEY-----(.*)-----END PRIVATE KEY-----$/s', $key)) {
+if (! preg_match('/^-----BEGIN (RSA )?PRIVATE KEY-----(.*)-----END (RSA )?PRIVATE KEY-----$/s', $key)) {
     echo "The private key does not appear to be valid\r\n";
     die(1);
 }


### PR DESCRIPTION
Currently the script will fail with the following error when an RSA formatted private key is used:

```
The private key does not appear to be valid
```

This is due to the key file being formatted internally as:

```
-----BEGIN RSA PRIVATE KEY-----
...
-----END RSA PRIVATE KEY-----
```

Instead of:

```
-----BEGIN PRIVATE KEY-----
...
-----END PRIVATE KEY-----
```

I've updated the script to match both formats.