### PR TITLE
Better key types validation

### DIFF
--- a/opnsense-import-ssl.php
+++ b/opnsense-import-ssl.php
@@ -65,7 +65,7 @@ if (! file_exists($argv[2])) {
 }
 
 $key = trim(file_get_contents($argv[2]));
-if (! preg_match('/^-----BEGIN (RSA )?PRIVATE KEY-----(.*)-----END (RSA )?PRIVATE KEY-----$/s', $key)) {
+if (! preg_match('/^-----BEGIN( | RSA | EC | DSA | ED25519 )PRIVATE KEY-----(.*)-----END\1PRIVATE KEY-----$', $key)) {
     echo "The private key does not appear to be valid\r\n";
     die(1);
 }


### PR DESCRIPTION
#3 added support for RSA private key but lacks support for other types.
#2 added support for more private key types but lacks support for no type.

This PR uses all the types included in #2 but brings back support for unspecified type.
Moreover it ensures that both type specified in the `BEGIN` and `END` directives are equal.

